### PR TITLE
Use in-place Xavier uniform initialization in essay score model

### DIFF
--- a/scoreblocks/essayscoremodel.py
+++ b/scoreblocks/essayscoremodel.py
@@ -69,7 +69,7 @@ def _initialize_arguments(p):
 
 def init_weights(m):
     if isinstance(m, nn.Linear):
-        torch.nn.init.xavier_uniform(m.weight)
+        torch.nn.init.xavier_uniform_(m.weight)
         m.bias.data.fill_(7)
 class model:
     def __init__(self):


### PR DESCRIPTION
## Summary
- switch the essay score model's linear layer initialization to use `torch.nn.init.xavier_uniform_`
- ensure weights are updated in place when initializing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8f083b4d8832a865c828fde3352b7