### PR TITLE
Fix get_score return indentation

### DIFF
--- a/score.py
+++ b/score.py
@@ -149,7 +149,7 @@ class scoresystem:
                             section_img = section_img[int(y1):int(y2), int(x1):int(x2)]
                             # 涂改选择题模型
                             pass
-            return total_result
+        return total_result
 
 
 


### PR DESCRIPTION
## Summary
- ensure get_score iterates through all outer segmentation results before returning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8f0855a48832a83f6ca3ad3c2e1c2